### PR TITLE
Serve frontend app through nodejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,6 @@ backend/node_modules/*
 YoutubeDL-Material/node_modules/*
 backend/video/*
 backend/audio/*
+backend/public/*
 backend/db.json
 src/assets/default.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,21 @@
-FROM ubuntu:18.04
+FROM alpine:3.11
 
-RUN apt-get update && apt-get install -y \
-  nodejs \
-  apache2 \
-  npm \
-  youtube-dl
+RUN apk add --update npm python ffmpeg
 
 # Change directory so that our commands run inside this new directory
-WORKDIR /var/www/html
+WORKDIR /app
 
 # Copy dependency definitions
-COPY ./ /var/www/html/
+COPY ./ /app/
 
 # Change directory to backend
-WORKDIR /var/www/html/backend
+WORKDIR /app
 
 # Install dependencies on backend
 RUN npm install
 
-# Change back to original directory
-WORKDIR /var/www/html
-
 # Expose the port the app runs in
-EXPOSE 80
+EXPOSE 17442
 
 # Run the specified command within the container.
-CMD ./docker_wrapper.sh
+CMD [ "node", "app.js" ]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo apt-get install nodejs youtube-dl
 
 1. First, download the [latest release](https://github.com/Tzahi12345/YoutubeDL-Material/releases/latest)!
 
-2. Drag all the files in `youtubedl-material` to an easily accessible directory. Navigate to the `backend` folder and edit the `default.json` file. If you're using SSL encryption, look at the `encrypted.json` file for a template.
+2. Drag all the files in `youtubedl-material` to an easily accessible directory. Navigate to the `config` folder and edit the `default.json` file. If you're using SSL encryption, look at the `encrypted.json` file for a template.
 
 NOTE: If you are intending to use a reverse proxy, this next step is not necessary
 3. Port forward the port listed in `default.json`, which defaults to `17442`.
@@ -44,6 +44,8 @@ NOTE: If you are intending to use a reverse proxy, this next step is not necessa
 If you experience problems, know that it's usually caused by a configuration problem. The first thing you should do is check the console. To get there, right click anywhere on the page and click "Inspect element." Then on the menu that pops up, click console. Look at the error there, and try to investigate.
 
 ### Configuration
+
+NOTE: If you are using YoutubeDL-Material v3.2 or lower, click [here](https://github.com/Tzahi12345/YoutubeDL-Material/blob/b87a9f1e2fd896b8e3b2f12429b7ffb15ea4521b/README.md#configuration) for the old README
 
 Here is an explanation for the configuration entries. Check out the [default config](https://github.com/Tzahi12345/YoutubeDL-Material/blob/master/backend/config/default.json) for more context.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Here is an explanation for the configuration entries. Check out the [default con
 | use-encryption | true if you intend to use SSL encryption (https) | false |
 | cert-file-path | Cert file path - required if using encryption | "/etc/letsencrypt/live/example.com/fullchain.pem" |
 | key-file-path | Private key file path - required if using encryption |  "/etc/letsencrypt/live/example.com/privkey.pem" |
-| path-base | Audio/video stream URL. Usually the same as backendurl | "http://example.com:17442/" |
 | path-audio | Path to audio folder for saved mp3s | "audio/" |
 | path-video | Path to video folder for saved mp4s | "video/" |
 | title_top | Title shown on the top toolbar | "Youtube Downloader" |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Dark mode:
 
 ### Prerequisites
 
-NOTE: If you would like to use Docker, you can go down to the [Docker](#Docker) section for a setup guide.
+NOTE: If you would like to use Docker, you can skip down to the [Docker](#Docker) section for a setup guide.
 
 You need to have a functioning web server for this to work. Also make sure you have these dependencies installed on your system: nodejs and youtube-dl. If you don't, run this command:
 
@@ -32,13 +32,14 @@ sudo apt-get install nodejs youtube-dl
 
 ### Installing
 
-First, download the [latest release](https://github.com/Tzahi12345/YoutubeDL-Material/releases/latest)!
+1. First, download the [latest release](https://github.com/Tzahi12345/YoutubeDL-Material/releases/latest)!
 
-Drag all the files in `youtubedl-material` to a location accessible to a web server. It works best if it's the root (usually right inside `public_html`. Once that's done, navigate to `backend` and edit the `default.json` file. If you're using SSL encryption, look at the `encrypted.json` file for a template. 
+2. Drag all the files in `youtubedl-material` to an easily accessible directory. Navigate to the `backend` folder and edit the `default.json` file. If you're using SSL encryption, look at the `encrypted.json` file for a template.
 
-Port forward `17442` if you're going to access YoutubeDL-Material from out of your network. This is an important step. Make sure the configuration reflects this appropriately.
+NOTE: If you are intending to use a reverse proxy, this next step is not necessary
+3. Port forward the port listed in `default.json`, which defaults to `17442`.
 
-Once the configuration is done, run `npm install` to install all the backend dependencies. Once that is finished, type `nodejs app.js`. This will run the backend server. On your browser, navigate to your installation folder. Try putting in a youtube link to see if it works. If it does, viola! YoutubeDL-Material is now up and running.
+4. Once the configuration is done, run `npm install` to install all the backend dependencies. Once that is finished, type `nodejs app.js`. This will run the backend server, which serves the frontend as well. On your browser, navigate to to the server (url with the specified port). Try putting in a youtube link to see if it works. If it does, viola! YoutubeDL-Material is now up and running.
 
 If you experience problems, know that it's usually caused by a configuration problem. The first thing you should do is check the console. To get there, right click anywhere on the page and click "Inspect element." Then on the menu that pops up, click console. Look at the error there, and try to investigate.
 
@@ -48,8 +49,8 @@ Here is an explanation for the configuration entries. Check out the [default con
 
 | Config item | Description | Default |
 | ------------- | ------------- | ------------- |
-| frontendurl  | URL to the webserver hosting YTDL-Material | "http://example.com" |
-| backendurl  | URL to the YTDL-Material's backend, should include port 17442 | "http://example.com:17442/" |
+| url  | URL to the server hosting YoutubeDL-Material | "http://example.com" |
+| port  | Desired port for YoutubeDL-Material | "17442" |
 | use-encryption | true if you intend to use SSL encryption (https) | false |
 | cert-file-path | Cert file path - required if using encryption | "/etc/letsencrypt/live/example.com/fullchain.pem" |
 | key-file-path | Private key file path - required if using encryption |  "/etc/letsencrypt/live/example.com/privkey.pem" |
@@ -74,21 +75,21 @@ If you'd like to install YoutubeDL-Material, go to the Installation section. If 
 
 To deploy, simply clone the repository, and go into the `youtubedl-material` directory. Type `npm install` and all the dependencies will install. Then type `cd backend` and again type `npm install` to install the dependencies for the backend.
 
-Once you do that, you're almost up and running. All you need to do is edit the configuration in `youtubedl-material/backend/config`, go back into the `youtubedl-material` directory, and type `ng build --prod`. This will build the app, and put the output files in the `youtubedl-material/dist` folder. Drag those files into a web server, and drag the `backend` directory into the same folder. This folder should have `index.html` in it as well. If it does **not**, you're in the wrong directory.
+Once you do that, you're almost up and running. All you need to do is edit the configuration in `youtubedl-material/backend/config`, go back into the `youtubedl-material` directory, and type `ng build --prod`. This will build the app, and put the output files in the `youtubedl-material/dist` folder. Drag those files into the `public` directory in the `backend` folder.
 
-The frontend is now complete. The backend is much easier. Just go into the `youtubedl-material/backend` folder, and type `sudo nodejs app.js`.
+The frontend is now complete. The backend is much easier. Just go into the `backend` folder, and type `nodejs app.js`.
 
-Finally, port forward the port `17442` and point it to the server's IP address. Make sure the port is also allowed through the firewall.
+Finally, port forward the port specified in the config (defaults to `17442`) and point it to the server's IP address. Make sure the port is also allowed through the server's firewall.
 
 ## Docker
 
 If you are looking to setup YoutubeDL-Material with Docker, this section is for you. And you're in luck! Docker setup is quite simple.
 
-1. Run `curl https://github.com/Tzahi12345/YoutubeDL-Material/releases/latest/download/docker-compose.yml -o docker-compose.yml` to download the latest release of `docker-compose.yml`, or go to the [releases](https://github.com/Tzahi12345/YoutubeDL-Material/releases/) page to grab the version you'd like.
-2. Modify the config items in the `environment` section of `docker-compose.yml` to your liking. Otherwise, the default options will work and point to `http://localhost:8998`. You can find an explanation of these configuration items in [Configuration](#Configuration) section. 
-3. Make sure the port in the `frontend_url` environment variable lines up with the port in the `ports` section.
-4. Run `docker-compose pull`. This will download the official YoutubeDL-Material docker image.
-5. Run `docker-compose up` to start it up. If successful, it should say "HTTP(S): Started on port 17442" or something similar. Make sure you can connect to the frontend, and if so, you are done!
+1. Run `curl -L https://github.com/Tzahi12345/YoutubeDL-Material/releases/latest/download/docker-compose.yml -o docker-compose.yml` to download the latest release of `docker-compose.yml`, or go to the [releases](https://github.com/Tzahi12345/YoutubeDL-Material/releases/) page to grab the version you'd like.
+2. Modify the config items in the `environment` section of `docker-compose.yml` to your liking. The default options will work, however, and point to `http://localhost:8998`. You can find an explanation of these configuration items in [Configuration](#Configuration) section. 
+3. Run `docker-compose pull`. This will download the official YoutubeDL-Material docker image.
+4. Run `docker-compose up` to start it up. If successful, it should say "HTTP(S): Started on port 8998" or something similar. 
+5. Make sure you can connect to the specified URL + port, and if so, you are done!
 
 ## Contributing
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -121,11 +121,9 @@ async function loadConfig() {
         // get config library
         // config = require('config');
 
-        // frontendUrl = !debugMode ? config_api.getConfigItem('ytdl_frontend_url') : 'http://localhost:4200';
         url = !debugMode ? config_api.getConfigItem('ytdl_url') : 'http://localhost:4200';
         backendPort = config_api.getConfigItem('ytdl_port');
         usingEncryption = config_api.getConfigItem('ytdl_use_encryption');
-        basePath = config_api.getConfigItem('ytdl_base_path');
         audioFolderPath = config_api.getConfigItem('ytdl_audio_folder_path');
         videoFolderPath = config_api.getConfigItem('ytdl_video_folder_path');
         downloadOnlyMode = config_api.getConfigItem('ytdl_download_only_mode');

--- a/backend/app.js
+++ b/backend/app.js
@@ -31,7 +31,7 @@ db.defaults(
 // config values
 var frontendUrl = null;
 var backendUrl = null;
-var backendPort = 17442;
+var backendPort = null;
 var usingEncryption = null;
 var basePath = null;
 var audioFolderPath = null;
@@ -85,7 +85,7 @@ function startServer() {
     if (usingEncryption)
     {
         https.createServer(options, app).listen(backendPort, function() {
-            console.log('HTTPS: Anchor set on 17442');
+            console.log('HTTPS: Started on PORT ' + backendPort);
         });
     }
     else
@@ -121,9 +121,9 @@ async function loadConfig() {
         // get config library
         // config = require('config');
 
-        frontendUrl = !debugMode ? config_api.getConfigItem('ytdl_frontend_url') : 'http://localhost:4200';
-        backendUrl = config_api.getConfigItem('ytdl_backend_url')
-        backendPort = 17442;
+        // frontendUrl = !debugMode ? config_api.getConfigItem('ytdl_frontend_url') : 'http://localhost:4200';
+        url = !debugMode ? config_api.getConfigItem('ytdl_url') : 'http://localhost:4200';
+        backendPort = config_api.getConfigItem('ytdl_port');
         usingEncryption = config_api.getConfigItem('ytdl_use_encryption');
         basePath = config_api.getConfigItem('ytdl_base_path');
         audioFolderPath = config_api.getConfigItem('ytdl_audio_folder_path');
@@ -149,7 +149,7 @@ async function loadConfig() {
             };
         }
 
-        url_domain = new URL(frontendUrl);
+        url_domain = new URL(url);
 
         // start the server here
         startServer();

--- a/backend/config.js
+++ b/backend/config.js
@@ -108,5 +108,6 @@ module.exports = {
     getConfigItem: getConfigItem,
     setConfigItem: setConfigItem,
     setConfigItems: setConfigItems,
+    getConfigFile: getConfigFile,
     CONFIG_ITEMS: CONFIG_ITEMS
 }

--- a/backend/config/default.json
+++ b/backend/config/default.json
@@ -10,7 +10,6 @@
         "key-file-path": "/etc/letsencrypt/live/example.com/privkey.pem"
       },
       "Downloader": {
-        "path-base": "http://example.com:17442/api/",
         "path-audio": "audio/",
         "path-video": "video/"
       },

--- a/backend/config/default.json
+++ b/backend/config/default.json
@@ -1,8 +1,8 @@
 {
     "YoutubeDLMaterial": {
         "Host": {
-            "frontendurl": "http://example.com",
-            "backendurl": "http://example.com:17442/"
+            "url": "http://example.com",
+            "port": "17442"
         },
       "Encryption": {
         "use-encryption": false,
@@ -10,7 +10,7 @@
         "key-file-path": "/etc/letsencrypt/live/example.com/privkey.pem"
       },
       "Downloader": {
-        "path-base": "http://example.com:17442/",
+        "path-base": "http://example.com:17442/api/",
         "path-audio": "audio/",
         "path-video": "video/"
       },

--- a/backend/config/encrypted.json
+++ b/backend/config/encrypted.json
@@ -1,16 +1,16 @@
 {
     "YoutubeDLMaterial": {
-        "Host": {
-            "frontendurl": "https://example.com",
-            "backendurl": "https://example.com:17442/"
-        },
+      "Host": {
+        "url": "https://example.com",
+        "port": "17442"
+      },
       "Encryption": {
         "use-encryption": true,
         "cert-file-path": "/etc/letsencrypt/live/example.com/fullchain.pem",
         "key-file-path": "/etc/letsencrypt/live/example.com/privkey.pem"
       },
       "Downloader": {
-        "path-base": "https://example.com:17442/",
+        "path-base": "https://example.com:17442/api/",
         "path-audio": "audio/",
         "path-video": "video/"
       },

--- a/backend/config/encrypted.json
+++ b/backend/config/encrypted.json
@@ -10,7 +10,6 @@
         "key-file-path": "/etc/letsencrypt/live/example.com/privkey.pem"
       },
       "Downloader": {
-        "path-base": "https://example.com:17442/api/",
         "path-audio": "audio/",
         "path-video": "video/"
       },

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -26,10 +26,6 @@ let CONFIG_ITEMS = {
     },
 
     // Downloader
-    'ytdl_base_path': {
-        'key': 'ytdl_base_path',
-        'path': 'YoutubeDLMaterial.Downloader.path-base'
-    },
     'ytdl_audio_folder_path': {
         'key': 'ytdl_audio_folder_path',
         'path': 'YoutubeDLMaterial.Downloader.path-audio'

--- a/backend/consts.js
+++ b/backend/consts.js
@@ -2,13 +2,13 @@ var config = require('config');
 
 let CONFIG_ITEMS = {
     // Host
-    'ytdl_frontend_url': {
-        'key': 'ytdl_frontend_url',
-        'path': 'YoutubeDLMaterial.Host.frontendurl'
+    'ytdl_url': {
+        'key': 'ytdl_url',
+        'path': 'YoutubeDLMaterial.Host.url'
     },
-    'ytdl_backend_url': {
-        'key': 'ytdl_backend_url',
-        'path': 'YoutubeDLMaterial.Host.backendurl'
+    'ytdl_port': {
+        'key': 'ytdl_port',
+        'path': 'YoutubeDLMaterial.Host.port'
     },
 
     // Encryption

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "archiver": "^3.1.1",
     "async": "^3.1.0",
+    "compression": "^1.7.4",
     "config": "^3.2.3",
     "exe": "^1.0.2",
     "express": "^4.17.1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,5 @@ services:
             ALLOW_CONFIG_MUTATIONS: 'true'
         restart: always
         ports:
-            - "17442:17442"
-            - "8998:80"
-        image: tzahi12345/youtubedl-material:3.2
+            - "8998:17442"
+        image: tzahi12345/youtubedl-material:3.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,11 @@ services:
         build: .
         environment: 
             # config items
-            ytdl_frontend_url: http://localhost:8998
-            ytdl_backend_url: http://localhost:17442/
+            ytdl_url: http://localhost:8998
+            ytdl_port: '17442'
             ytdl_use_encryption: 'false'
             ytdl_cert_file_path: /etc/letsencrypt/live/example.com/fullchain.pem
             ytdl_key_file_path: /etc/letsencrypt/live/example.com/privkey.pem
-            ytdl_base_path: http://localhost:17442/
             ytdl_audio_folder_path: audio/
             ytdl_video_folder_path: video/
             ytdl_title_top: Youtube Downloader

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -40,7 +40,8 @@ export class AppComponent implements OnInit {
     public router: Router, public overlayContainer: OverlayContainer, private elementRef: ElementRef) {
 
     // loading config
-    this.postsService.loadNavItems().subscribe(result => { // loads settings
+    this.postsService.loadNavItems().subscribe(res => { // loads settings
+      const result = !this.postsService.debugMode ? res['config_file'] : res;
       this.topBarTitle = result['YoutubeDLMaterial']['Extra']['title_top'];
       const themingExists = result['YoutubeDLMaterial']['Themes'];
       this.defaultTheme = themingExists ? result['YoutubeDLMaterial']['Themes']['default_theme'] : 'default';

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -204,7 +204,6 @@ export class MainComponent implements OnInit {
     // loading config
     this.postsService.loadNavItems().subscribe(res => { // loads settings
       const result = !this.postsService.debugMode ? res['config_file'] : res;
-      const backendUrl = result['YoutubeDLMaterial']['Host']['backendurl'];
       this.fileManagerEnabled = result['YoutubeDLMaterial']['Extra']['file_manager_enabled'];
       this.downloadOnlyMode = result['YoutubeDLMaterial']['Extra']['download_only_mode'];
       this.allowMultiDownloadMode = result['YoutubeDLMaterial']['Extra']['allow_multi_download_mode'];
@@ -217,9 +216,6 @@ export class MainComponent implements OnInit {
       this.allowQualitySelect = result['YoutubeDLMaterial']['Extra']['allow_quality_select'];
       this.allowAdvancedDownload = result['YoutubeDLMaterial']['Advanced']['allow_advanced_download'];
 
-      this.postsService.path = backendUrl + 'api/';
-      this.postsService.startPath = backendUrl;
-      this.postsService.startPathSSL = backendUrl;
 
       if (this.fileManagerEnabled) {
         this.getMp3s();
@@ -395,7 +391,7 @@ export class MainComponent implements OnInit {
 
     if (new_download && this.current_download !== new_download) {
       // console.log('mismatched downloads');
-    } else if (!this.multiDownloadMode) {
+    } else if (!this.multiDownloadMode || !new_download) {
       // if download only mode, just download the file. no redirect
       if (forceView === false && this.downloadOnlyMode && !this.iOS) {
         if (is_playlist) {
@@ -434,7 +430,7 @@ export class MainComponent implements OnInit {
 
     if (new_download && this.current_download !== new_download) {
       // console.log('mismatched downloads');
-    } else if (!this.multiDownloadMode) {
+    } else if (!this.multiDownloadMode || !new_download) {
       // if download only mode, just download the file. no redirect
       if (forceView === false && this.downloadOnlyMode) {
         if (is_playlist) {

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ElementRef, ViewChild, ViewChildren, QueryList } from '@angular/core';
+import { Component, OnInit, ElementRef, ViewChild, ViewChildren, QueryList, isDevMode } from '@angular/core';
 import {PostsService} from '../posts.services';
 import {FileCardComponent} from '../file-card/file-card.component';
 import { Observable } from 'rxjs/Observable';
@@ -202,7 +202,8 @@ export class MainComponent implements OnInit {
     this.audioOnly = false;
 
     // loading config
-    this.postsService.loadNavItems().subscribe(result => { // loads settings
+    this.postsService.loadNavItems().subscribe(res => { // loads settings
+      const result = !this.postsService.debugMode ? res['config_file'] : res;
       const backendUrl = result['YoutubeDLMaterial']['Host']['backendurl'];
       this.fileManagerEnabled = result['YoutubeDLMaterial']['Extra']['file_manager_enabled'];
       this.downloadOnlyMode = result['YoutubeDLMaterial']['Extra']['download_only_mode'];
@@ -216,7 +217,7 @@ export class MainComponent implements OnInit {
       this.allowQualitySelect = result['YoutubeDLMaterial']['Extra']['allow_quality_select'];
       this.allowAdvancedDownload = result['YoutubeDLMaterial']['Advanced']['allow_advanced_download'];
 
-      this.postsService.path = backendUrl;
+      this.postsService.path = backendUrl + 'api/';
       this.postsService.startPath = backendUrl;
       this.postsService.startPathSSL = backendUrl;
 

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -62,7 +62,6 @@ export class MainComponent implements OnInit {
   allowQualitySelect = false;
   downloadOnlyMode = false;
   allowMultiDownloadMode = false;
-  baseStreamPath;
   audioFolderPath;
   videoFolderPath;
   allowAdvancedDownload = false;
@@ -207,7 +206,6 @@ export class MainComponent implements OnInit {
       this.fileManagerEnabled = result['YoutubeDLMaterial']['Extra']['file_manager_enabled'];
       this.downloadOnlyMode = result['YoutubeDLMaterial']['Extra']['download_only_mode'];
       this.allowMultiDownloadMode = result['YoutubeDLMaterial']['Extra']['allow_multi_download_mode'];
-      this.baseStreamPath = result['YoutubeDLMaterial']['Downloader']['path-base'];
       this.audioFolderPath = result['YoutubeDLMaterial']['Downloader']['path-audio'];
       this.videoFolderPath = result['YoutubeDLMaterial']['Downloader']['path-video'];
       this.youtubeSearchEnabled = result['YoutubeDLMaterial']['API'] && result['YoutubeDLMaterial']['API']['use_youtube_API'] &&
@@ -403,10 +401,8 @@ export class MainComponent implements OnInit {
       } else {
         if (is_playlist) {
           this.router.navigate(['/player', {fileNames: name.join('|nvr|'), type: 'audio'}]);
-          // window.location.href = this.baseStreamPath + this.audioFolderPath + name[0] + '.mp3';
         } else {
           this.router.navigate(['/player', {fileNames: name, type: 'audio'}]);
-          // window.location.href = this.baseStreamPath + this.audioFolderPath + name + '.mp3';
         }
       }
     }
@@ -442,10 +438,8 @@ export class MainComponent implements OnInit {
       } else {
         if (is_playlist) {
           this.router.navigate(['/player', {fileNames: name.join('|nvr|'), type: 'video'}]);
-          // window.location.href = this.baseStreamPath + this.videoFolderPath + name[0] + '.mp4';
         } else {
           this.router.navigate(['/player', {fileNames: name, type: 'video'}]);
-          // window.location.href = this.baseStreamPath + this.videoFolderPath + name + '.mp4';
         }
       }
     }

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -58,11 +58,7 @@ export class PlayerComponent implements OnInit {
       this.baseStreamPath = result['YoutubeDLMaterial']['Downloader']['path-base'];
       this.audioFolderPath = result['YoutubeDLMaterial']['Downloader']['path-audio'];
       this.videoFolderPath = result['YoutubeDLMaterial']['Downloader']['path-video'];
-      const backendUrl = result['YoutubeDLMaterial']['Host']['backendurl'];
 
-      this.postsService.path = backendUrl + 'api/';
-      this.postsService.startPath = backendUrl;
-      this.postsService.startPathSSL = backendUrl;
 
       let fileType = null;
       if (this.type === 'audio') {

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -53,13 +53,14 @@ export class PlayerComponent implements OnInit {
     this.id = this.route.snapshot.paramMap.get('id');
 
     // loading config
-    this.postsService.loadNavItems().subscribe(result => { // loads settings
+    this.postsService.loadNavItems().subscribe(res => { // loads settings
+      const result = !this.postsService.debugMode ? res['config_file'] : res;
       this.baseStreamPath = result['YoutubeDLMaterial']['Downloader']['path-base'];
       this.audioFolderPath = result['YoutubeDLMaterial']['Downloader']['path-audio'];
       this.videoFolderPath = result['YoutubeDLMaterial']['Downloader']['path-video'];
       const backendUrl = result['YoutubeDLMaterial']['Host']['backendurl'];
 
-      this.postsService.path = backendUrl;
+      this.postsService.path = backendUrl + 'api/';
       this.postsService.startPath = backendUrl;
       this.postsService.startPathSSL = backendUrl;
 

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -55,7 +55,7 @@ export class PlayerComponent implements OnInit {
     // loading config
     this.postsService.loadNavItems().subscribe(res => { // loads settings
       const result = !this.postsService.debugMode ? res['config_file'] : res;
-      this.baseStreamPath = result['YoutubeDLMaterial']['Downloader']['path-base'];
+      this.baseStreamPath = this.postsService.path;
       this.audioFolderPath = result['YoutubeDLMaterial']['Downloader']['path-audio'];
       this.videoFolderPath = result['YoutubeDLMaterial']['Downloader']['path-video'];
 

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -30,6 +30,7 @@ export class PostsService {
 
         if (isDevMode()) {
             this.debugMode = true;
+            this.path = 'http://localhost:17442/api/';
         }
     }
 

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -1,4 +1,4 @@
-import {Injectable, isDevMode} from '@angular/core';
+import {Injectable, isDevMode, Inject} from '@angular/core';
 import { HttpClient, HttpHeaders, HttpRequest, HttpResponseBase } from '@angular/common/http';
 import config from '../assets/default.json';
 import 'rxjs/add/operator/map';
@@ -7,20 +7,30 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/throw';
 import { THEMES_CONFIG } from '../themes';
+import { Router } from '@angular/router';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable()
 export class PostsService {
     path = '';
     audioFolder = '';
     videoFolder = '';
-    startPath = 'http://localhost:17442/';
-    startPathSSL = 'https://localhost:17442/'
+    startPath = null; // 'http://localhost:17442/';
+    startPathSSL = null; // 'https://localhost:17442/'
     handShakeComplete = false;
     THEMES_CONFIG = THEMES_CONFIG;
     theme;
 
-    constructor(private http: HttpClient) {
+    debugMode = false;
+    constructor(private http: HttpClient, private router: Router, @Inject(DOCUMENT) private document: Document) {
         console.log('PostsService Initialized...');
+        // this.startPath = window.location.href + '/api/';
+        // this.startPathSSL = window.location.href + '/api/';
+        this.path = this.document.location.origin + '/api/';
+
+        if (isDevMode()) {
+            this.debugMode = true;
+        }
     }
 
     setTheme(theme) {
@@ -72,10 +82,9 @@ export class PostsService {
     loadNavItems() {
         if (isDevMode()) {
             return this.http.get('./assets/default.json');
+        } else {
+            return this.http.get(this.path + 'config');
         }
-        const locations = window.location.href.split('#');
-        const current_location = locations[0];
-        return this.http.get(current_location + 'backend/config/default.json');
     }
 
     deleteFile(name: string, isAudio: boolean) {

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -1,16 +1,16 @@
 {
     "YoutubeDLMaterial": {
-        "Host": {
-            "frontendurl": "http://localhost:4200",
-            "backendurl": "http://localhost:17442/"
-        },
+      "Host": {
+        "url": "http://localhost",
+        "port": "17442"
+      },
       "Encryption": {
         "use-encryption": false,
         "cert-file-path": "/etc/letsencrypt/live/example.com/fullchain.pem",
         "key-file-path": "/etc/letsencrypt/live/example.com/privkey.pem"
       },
       "Downloader": {
-        "path-base": "http://localhost:17442/",
+        "path-base": "http://localhost:17442/api/",
         "path-audio": "audio/",
         "path-video": "video/"
       },

--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -10,7 +10,6 @@
         "key-file-path": "/etc/letsencrypt/live/example.com/privkey.pem"
       },
       "Downloader": {
-        "path-base": "http://localhost:17442/api/",
         "path-audio": "audio/",
         "path-video": "video/"
       },


### PR DESCRIPTION
This PR refactors the code such that the frontend app is not served by a user's webserver, but rather the nodejs YTDL-Material backend. This is to simplify the stack's deployment and routing configurations (one URL to deal with instead of two).

Backend routes are now prepended with /api/