### PR TITLE
Streaming-only mode

### DIFF
--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
@@ -29,6 +29,9 @@
                     </mat-option>
                 </mat-select>
             </div>
+            <div>
+                <mat-checkbox [(ngModel)]="streamingOnlyMode">Streaming-only mode</mat-checkbox>
+            </div>
         </div>
     </div>
 </mat-dialog-content>
@@ -36,7 +39,7 @@
 <mat-dialog-actions>
     <button mat-button mat-dialog-close><ng-container i18n="Subscribe cancel button">Cancel</ng-container></button>
     <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
-    <button mat-button [disabled]="!url" type="submit" (click)="subscribeClicked()">Subscribe</button>
+    <button mat-button [disabled]="!url" type="submit" (click)="subscribeClicked()"><ng-container i18n="Subscribe button">Subscribe</ng-container></button>
     <div class="mat-spinner" *ngIf="subscribing">
       <mat-spinner [diameter]="25"></mat-spinner>
     </div>

--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.html
@@ -29,8 +29,10 @@
                     </mat-option>
                 </mat-select>
             </div>
-            <div>
-                <mat-checkbox [(ngModel)]="streamingOnlyMode">Streaming-only mode</mat-checkbox>
+            <div class="col-12">
+                <div>
+                    <mat-checkbox [(ngModel)]="streamingOnlyMode">Streaming-only mode</mat-checkbox>
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.ts
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.ts
@@ -19,6 +19,9 @@ export class SubscribeDialogComponent implements OnInit {
   // state
   subscribing = false;
 
+  // no videos actually downloaded, just streamed
+  streamingOnlyMode = false;
+
   time_units = [
     'day',
     'week',

--- a/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.ts
+++ b/src/app/dialogs/subscribe-dialog/subscribe-dialog.component.ts
@@ -49,8 +49,7 @@ export class SubscribeDialogComponent implements OnInit {
       if (!this.download_all) {
         timerange = 'now-' + this.timerange_amount.toString() + this.timerange_unit;
       }
-
-      this.postsService.createSubscription(this.url, this.name, timerange).subscribe(res => {
+      this.postsService.createSubscription(this.url, this.name, timerange, this.streamingOnlyMode).subscribe(res => {
         this.subscribing = false;
         if (res['new_sub']) {
           this.dialogRef.close(res['new_sub']);

--- a/src/app/dialogs/video-info-dialog/video-info-dialog.component.html
+++ b/src/app/dialogs/video-info-dialog/video-info-dialog.component.html
@@ -15,15 +15,15 @@
     </div>
     <div class="info-item">
         <div class="info-item-label"><strong><ng-container i18n="Video file size property">File size:</ng-container>&nbsp;</strong></div>
-        <div class="info-item-value">{{filesize(file.size)}}</div>
+        <div class="info-item-value">{{file.size ? filesize(file.size) : 'N/A'}}</div>
     </div>
     <div class="info-item">
         <div class="info-item-label"><strong><ng-container i18n="Video path property">Path:</ng-container>&nbsp;</strong></div>
-        <div class="info-item-value">{{file.path}}</div>
+        <div class="info-item-value">{{file.path ? file.path : 'N/A'}}</div>
     </div>
     <div class="info-item">
         <div class="info-item-label"><strong><ng-container i18n="Video upload date property">Upload Date:</ng-container>&nbsp;</strong></div>
-        <div class="info-item-value">{{file.upload_date}}</div>
+        <div class="info-item-value">{{file.upload_date ? file.upload_date : 'N/A'}}</div>
     </div>
 </mat-dialog-content>
 

--- a/src/app/posts.services.ts
+++ b/src/app/posts.services.ts
@@ -184,8 +184,8 @@ export class PostsService {
         return this.http.post(this.path + 'deletePlaylist', {playlistID: playlistID, type: type});
     }
 
-    createSubscription(url, name, timerange = null) {
-        return this.http.post(this.path + 'subscribe', {url: url, name: name, timerange: timerange})
+    createSubscription(url, name, timerange = null, streamingOnly = false) {
+        return this.http.post(this.path + 'subscribe', {url: url, name: name, timerange: timerange, streamingOnly: streamingOnly});
     }
 
     unsubscribe(sub, deleteMode = false) {

--- a/src/app/subscription/subscription-file-card/subscription-file-card.component.ts
+++ b/src/app/subscription/subscription-file-card/subscription-file-card.component.ts
@@ -54,7 +54,11 @@ export class SubscriptionFileCardComponent implements OnInit {
   }
 
   goToFile() {
-    this.goToFileEmit.emit(this.file.id);
+    const emit_obj = {
+      name: this.file.id,
+      url: this.file.requested_formats ? this.file.requested_formats[0].url : this.file.url
+    }
+    this.goToFileEmit.emit(emit_obj);
   }
 
   openSubscriptionInfoDialog() {

--- a/src/app/subscription/subscription/subscription.component.ts
+++ b/src/app/subscription/subscription/subscription.component.ts
@@ -84,10 +84,16 @@ export class SubscriptionComponent implements OnInit {
     });
   }
 
-  goToFile(name) {
+  goToFile(emit_obj) {
+    const name = emit_obj['name'];
+    const url = emit_obj['url'];
     localStorage.setItem('player_navigator', this.router.url);
-    this.router.navigate(['/player', {fileNames: name, type: 'subscription', subscriptionName: this.subscription.name,
-                                      subPlaylist: this.subscription.isPlaylist}]);
+    if (this.subscription.streamingOnly) {
+      this.router.navigate(['/player', {name: name, url: url}]);
+    } else {
+      this.router.navigate(['/player', {fileNames: name, type: 'subscription', subscriptionName: this.subscription.name,
+                                        subPlaylist: this.subscription.isPlaylist}]);
+    }
   }
 
   onSearchInputChanged(newvalue) {


### PR DESCRIPTION
Added the ability to enable "streaming-only mode" for subscriptions. This can be set from the "Subscribe" dialog.

Subscriptions that have this option enabled will not download the videos, and instead will periodically get info on the videos like the stream URL, name, uploader, etc.

This mode doesn't come with many caveats. It significantly reduces disk usage from megabytes or gigabytes to just a few bytes for each video. Videos might take a few more seconds to load as they are streamed from an outside URL rather than directly from the file.