### PR TITLE
DOCS: Change relative to absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Here is an explanation for the configuration entries. Check out the [default con
 | use-encryption | true if you intend to use SSL encryption (https) | false |
 | cert-file-path | Cert file path - required if using encryption | "/etc/letsencrypt/live/example.com/fullchain.pem" |
 | key-file-path | Private key file path - required if using encryption |  "/etc/letsencrypt/live/example.com/privkey.pem" |
-| path-audio | Path to audio folder for saved mp3s | "audio/" |
-| path-video | Path to video folder for saved mp4s | "video/" |
+| path-audio | Path to audio folder for saved mp3s | "/app/audio/" |
+| path-video | Path to video folder for saved mp4s | "/app/video/" |
 | title_top | Title shown on the top toolbar | "Youtube Downloader" |
 | file_manager_enabled | true if you want to use the file manager | true |
 | allow_quality_select | true if you want to select a videos quality level before downloading | true |


### PR DESCRIPTION
Displaying the absolute path to the audio and video save matches conformity of other paths stated (certs) and clarifies them for docker users who need to map volumes.

NOTE: I don't have subscriptions setup but if I remember correctly there is an /app/subscriptions directory and probably should be mentioned as well. I'll add to this PR if you verify.