### PR TITLE
Dockerfile: do not use root processes (fix #72)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,15 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
-RUN \ 
-apk add --no-cache npm python ffmpeg && \
+ENV UID=991 GID=991
+
+RUN \
+apk add --no-cache npm python2 ffmpeg tini su-exec && \
 apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
     atomicparsley
 
 WORKDIR /app
+
+COPY docker_run.sh /usr/local/bin/run.sh
 
 COPY package.json /app/
 
@@ -15,4 +19,6 @@ COPY ./ /app/
 
 EXPOSE 17442
 
-CMD [ "node", "app.js" ]
+RUN chmod +x /usr/local/bin/run.sh
+
+CMD ["run.sh"]

--- a/backend/docker_run.sh
+++ b/backend/docker_run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+chown -R $UID:$GID /app
+exec su-exec $UID:$GID /sbin/tini -- node app.js


### PR DESCRIPTION
Hi! First and foremost, I have to thank you for this great app.

Unfortunately, I was not at ease using your official Docker image which is running everything as `root` by default. I mean, it's possible to get rid of that issue with user namespaces, but that's a bit tricky (especially with volume points and all that stuff) for someone who just wants to deploy your app as soon as possible.

Therefore I've made some changes to your image and it runs flawlessly. I usually use `tini` in conjunction with `su-exec` to run everything under a non-root user (uid/gid can be set with `UID` and `GID` environment variables). To avoid permission issues, the startup script runs a recursive `chown` at startup (which can be slower on `overlay2` due to performance issues in this very specific case, otherwise it's not noticeable). It fixes #72.

It's a drop-in replacement and requires basically no changes to previous installations, but there has to be a note that permissions to the volumes will be changed accordingly, and that by default permissions will be changed for 991/991 as UID/GID (arbitrary choice).

I think it's something that needs to be addressed ASAP as running as root even in containers is considered a security bad practice, whether you like my solution or not. An alternative would be to specify a `USER` directive in the `Dockerfile`, which works too, but it's not as flexible and will cause frustration among Docker beginners.

By the way, if you merge this, I also upgraded the Dockerfile to Alpine 3.12 which was released some days ago. `python` is not a valid package anymore, so I had to specify `python2`.

Again, thanks for your work!