### PR TITLE
Run docker as non root

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,20 +1,25 @@
 FROM alpine:3.12
 
+ENV UID=1000 GID=1000
+RUN export user=youtube \
+  && addgroup -S $user -g $GID && adduser -D -S $user -G $user -u $UID
+USER $user
+
 RUN apk add --no-cache \
+    ffmpeg \
     npm \
     python2 \
-    ffmpeg \
+    su-exec  \
   && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
     atomicparsley
 
 WORKDIR /app
 
-COPY package.json /app/
-
+COPY --chown=$UID:$GID [ "package.json", "package-lock.json", "/app/" ]
 RUN npm install
 
-COPY ./ /app/
+COPY --chown=$UID:$GID [ "./", "/app/" ]
 
 EXPOSE 17442
-
+ENTRYPOINT [ "/app/entrypoint.sh" ]
 CMD [ "node", "app.js" ]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+
+CMD="node app.js"
+
+# if the first arg starts with "-" pass it to program
+if [ "${1#-}" != "$1" ]; then
+  set -- "$CMD" "$@"
+fi
+
+# chown current working directory to current user
+if [ "$@" = "$CMD" ] && [ "$(id -u)" = "0" ]; then
+  find . \! -user "$UID" -exec chown "$UID:$GID" -R '{}' +
+  exec su-exec "$UID:$GID" "$0" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This changes the docker image to allow it to run as non root. It also copies the lock file for npm in which I was to lazy to separate after fixing permissions issues. Startup time with default UID/GID is negligible effected but when changing them it takes a few seconds to chown all files.