### PR TITLE
Make more items translatable

### DIFF
--- a/backend/public/assets/i18n/messages.de.json
+++ b/backend/public/assets/i18n/messages.de.json
@@ -183,7 +183,7 @@
   "b7ff2e2b909c53abe088fe60b9f4b6ac7757247f": "Nutzer registrieren",
   "024886ca34a6f309e3e51c2ed849320592c3faaa": "Benutzername",
   "2bd201aea09e43fbfd3cd15ec0499b6755302329": "Benutzer verwalten",
-  "29c97c8e76763bb15b6d515648fa5bd1eb0f7510": "Benutzer-UID",
+  "29c97c8e76763bb15b6d515648fa5bd1eb0f7510": "Benutzer-UID:",
   "e70e209561583f360b1e9cefd2cbb1fe434b6229": "Neues Passwort",
   "6498fa1b8f563988f769654a75411bb8060134b9": "Neues Passwort festlegen",
   "40da072004086c9ec00d125165da91eaade7f541": "Standard verwenden",

--- a/src/app/components/downloads/downloads.component.html
+++ b/src/app/components/downloads/downloads.component.html
@@ -15,7 +15,7 @@
                     </div>
                 </div>
                 <div>
-                    <button style="top: 15px;" (click)="clearDownloads(session_downloads.key)" mat-stroked-button color="warn">Clear all downloads</button>
+                    <button style="top: 15px;" (click)="clearDownloads(session_downloads.key)" mat-stroked-button color="warn"><ng-container i18n="clear all downloads action button">Clear all downloads</ng-container></button>
                 </div>
             </mat-card>
         </ng-container>

--- a/src/app/components/manage-user/manage-user.component.html
+++ b/src/app/components/manage-user/manage-user.component.html
@@ -16,7 +16,7 @@
                 <h3 matLine>{{permissionToLabel[permission] ? permissionToLabel[permission] : permission}}</h3>
                 <span matLine>
                     <mat-radio-group [disabled]="permission === 'settings' && postsService.user.uid === user.uid" (change)="changeUserPermissions($event, permission)" [(ngModel)]="permissions[permission]" [attr.aria-label]="'Give user permission for ' + permission">
-                        <mat-radio-button value="default"><ng-container i18n="Use default">Use default</ng-container></mat-radio-button>
+                        <mat-radio-button value="default"><ng-container i18n="Use role default">Use role default</ng-container></mat-radio-button>
                         <mat-radio-button value="yes"><ng-container i18n="Yes">Yes</ng-container></mat-radio-button>
                         <mat-radio-button value="no"><ng-container i18n="No">No</ng-container></mat-radio-button>
                     </mat-radio-group>
@@ -27,5 +27,5 @@
 </mat-dialog-content>
 
 <mat-dialog-actions>
-    <button mat-button mat-dialog-close><ng-container i18n="Close">Close</ng-container></button>
+    <button style="margin-bottom: 5px;" mat-stroked-button mat-dialog-close><ng-container i18n="Close">Close</ng-container></button>
 </mat-dialog-actions>

--- a/src/app/components/modify-users/modify-users.component.html
+++ b/src/app/components/modify-users/modify-users.component.html
@@ -4,7 +4,7 @@
         <div class="table table-responsive px-5 pb-4 pt-2">
         <div class="example-header">
             <mat-form-field>
-            <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search">
+            <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search" i18n-placeholder="search field description">
             </mat-form-field>
         </div>
         
@@ -55,22 +55,22 @@
                 <mat-header-cell *matHeaderCellDef mat-sort-header><ng-container i18n="Actions users table header"> Actions </ng-container></mat-header-cell>
                 <mat-cell *matCellDef="let row">
                 <span *ngIf="editObject && editObject.uid === row.uid; else notediting">
-                    <button mat-icon-button color="primary" (click)="finishEditing(row.uid)"  matTooltip="Finish editing user">
+                    <button mat-icon-button color="primary" (click)="finishEditing(row.uid)" matTooltip="Save" i18n-matTooltip="save user edit action button tooltip">
                     <mat-icon>done</mat-icon>
                     </button>
-                    <button mat-icon-button (click)="disableEditMode()" matTooltip="Cancel editing user">
+                    <button mat-icon-button (click)="disableEditMode()" matTooltip="Cancel" i18n-matTooltip="cancel user edit action button tooltip">
                     <mat-icon>cancel</mat-icon>
                     </button>
                 </span>
                 <ng-template #notediting>
-                    <button mat-icon-button (click)="enableEditMode(row.uid)" matTooltip="Edit user">
+                    <button mat-icon-button (click)="enableEditMode(row.uid)" matTooltip="Edit user" i18n-matTooltip="edit user action button tooltip">
                     <mat-icon>edit</mat-icon>
                     </button>
                 </ng-template>
-                <button (click)="manageUser(row.uid)" mat-icon-button [disabled]="editObject && editObject.uid === row.uid" matTooltip="Manage user">
+                <button (click)="manageUser(row.uid)" mat-icon-button [disabled]="editObject && editObject.uid === row.uid" matTooltip="Manage user" i18n-matTooltip="manage user action button tooltip">
                     <mat-icon>settings</mat-icon>
                 </button>
-                <button mat-icon-button [disabled]="editObject && editObject.uid === row.uid || row.uid === postsService.user.uid" (click)="removeUser(row.uid)" matTooltip="Delete user">
+                <button mat-icon-button [disabled]="editObject && editObject.uid === row.uid || row.uid === postsService.user.uid" (click)="removeUser(row.uid)" matTooltip="Delete user" i18n-matTooltip="delete user action button tooltip">
                     <mat-icon>delete</mat-icon>
                 </button>
                 </mat-cell>

--- a/src/app/dialogs/about-dialog/about-dialog.component.html
+++ b/src/app/dialogs/about-dialog/about-dialog.component.html
@@ -28,5 +28,5 @@
 </mat-dialog-content>
 
 <mat-dialog-actions>
-    <button style="margin-bottom: 5px;" mat-stroked-button mat-dialog-close>Close</button>
+    <button style="margin-bottom: 5px;" mat-stroked-button mat-dialog-close><ng-container i18n="Close">Close</ng-container></button>
 </mat-dialog-actions>

--- a/src/app/download-item/download-item.component.html
+++ b/src/app/download-item/download-item.component.html
@@ -5,8 +5,8 @@
         </mat-grid-tile>
         <mat-grid-tile [colspan]="13">
                 <mat-progress-bar [value]="(download.complete || download.error) ? 100 : download.percent_complete" [mode]="(!download.complete && download.percent_complete === 0 && !download.error) ? 'indeterminate' : 'determinate'"></mat-progress-bar>
-                <mat-icon *ngIf="download.complete" style="margin-left: 25px; cursor: default" matTooltip="The download is complete" matTooltip-i18n>done</mat-icon>
-                <mat-icon *ngIf="download.error" style="margin-left: 25px; cursor: default" matTooltip="An error has occurred" matTooltip-i18n>error</mat-icon>
+                <mat-icon *ngIf="download.complete" style="margin-left: 25px; cursor: default" matTooltip="The download was successful" i18n-matTooltip="download successful tooltip">done</mat-icon>
+                <mat-icon *ngIf="download.error" style="margin-left: 25px; cursor: default" matTooltip="An error has occurred" i18n-matTooltip="download error tooltip">error</mat-icon>
         </mat-grid-tile>
         <mat-grid-tile [colspan]="4">
             <button style="margin-bottom: 2px;" (click)="cancelTheDownload()" mat-icon-button color="warn"><mat-icon fontSet="material-icons-outlined">cancel</mat-icon></button>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -150,7 +150,7 @@
 
                     <div class="col-12 mt-4">
                         <mat-checkbox color="accent" [(ngModel)]="new_config['Downloader']['use_youtubedl_archive']"><ng-container i18n="Use youtubedl archive setting">Use youtube-dl archive</ng-container></mat-checkbox>
-                        <p>Note: This setting only applies to downloads on the Home page. If you would like to use youtube-dl archive functionality in subscriptions, head to the Main tab and activate this option there.</p>
+                        <p><ng-container i18n="youtubedl archive setting Note">Note: This setting only applies to downloads on the Home page. If you would like to use youtube-dl archive functionality in subscriptions, head to the Main tab and activate this option there.</ng-container></p>
                     </div>
 
                     <div class="col-12 mt-3">
@@ -206,7 +206,7 @@
                             </mat-form-field>
                         </div>
                         <div class="api-key-div">
-                            <button matTooltip-i18n matTooltip="This will delete your old API key!" mat-stroked-button (click)="generateAPIKey()"><ng-container i18n="Generate key button">Generate</ng-container></button>
+                            <button matTooltip="This will delete your old API key!" i18n-matTooltip="delete api key tooltip" mat-stroked-button (click)="generateAPIKey()"><ng-container i18n="Generate key button">Generate</ng-container></button>
                         </div>
                     </div>
                 </div>

--- a/src/assets/i18n/messages.de.json
+++ b/src/assets/i18n/messages.de.json
@@ -183,7 +183,7 @@
   "b7ff2e2b909c53abe088fe60b9f4b6ac7757247f": "Nutzer registrieren",
   "024886ca34a6f309e3e51c2ed849320592c3faaa": "Benutzername",
   "2bd201aea09e43fbfd3cd15ec0499b6755302329": "Benutzer verwalten",
-  "29c97c8e76763bb15b6d515648fa5bd1eb0f7510": "Benutzer-UID",
+  "29c97c8e76763bb15b6d515648fa5bd1eb0f7510": "Benutzer-UID:",
   "e70e209561583f360b1e9cefd2cbb1fe434b6229": "Neues Passwort",
   "6498fa1b8f563988f769654a75411bb8060134b9": "Neues Passwort festlegen",
   "40da072004086c9ec00d125165da91eaade7f541": "Standard verwenden",

--- a/src/assets/i18n/messages.de.xlf
+++ b/src/assets/i18n/messages.de.xlf
@@ -1772,7 +1772,7 @@
       </trans-unit>
       <trans-unit id="29c97c8e76763bb15b6d515648fa5bd1eb0f7510" datatype="html">
         <source>User UID:</source>
-        <target xml:lang="de-DE">Benutzer-UID</target>
+        <target xml:lang="de-DE">Benutzer-UID:</target>
 <note from="description" priority="1">User UID</note><context-group purpose="location">
           <context context-type="sourcefile">app/components/manage-user/manage-user.component.html</context>
           <context context-type="linenumber">4</context>


### PR DESCRIPTION
See title.

As you can see below, the close button is not translated. (The shown item is only one of the many improvements).
![image](https://user-images.githubusercontent.com/49200216/87100721-71753b00-c24d-11ea-8f6b-83b31868d2be.png)

And I've also uniformed the close button.