### PR TITLE
Switch from bcrypt to bcryptjs to keep compatibility with Raspberry Pi and a Dockerfile-armhf bonus

### DIFF
--- a/backend/Dockerfile-armhf
+++ b/backend/Dockerfile-armhf
@@ -1,0 +1,27 @@
+FROM arm32v7/alpine:3.12
+
+ENV UID=1000 \
+  GID=1000 \
+  USER=youtube
+
+RUN addgroup -S $USER -g $GID && adduser -D -S $USER -G $USER -u $UID
+
+RUN apk add --no-cache \
+    ffmpeg \
+    npm \
+    python2 \
+    su-exec  \
+  && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+    atomicparsley
+
+WORKDIR /app
+COPY --chown=$UID:$GID [ "package.json", "package-lock.json", "/app/" ]
+
+RUN npm install && chown -R $UID:$GID ./
+
+COPY --chown=$UID:$GID [ "./", "/app/" ]
+
+EXPOSE 17442
+
+ENTRYPOINT [ "/app/entrypoint.sh" ]
+CMD [ "node", "app.js" ]

--- a/backend/authentication/auth.js
+++ b/backend/authentication/auth.js
@@ -5,7 +5,7 @@ var subscriptions_api = require('../subscriptions')
 const fs = require('fs-extra');
 var jwt = require('jsonwebtoken');
 const { uuid } = require('uuidv4');
-var bcrypt = require('bcrypt');
+var bcrypt = require('bcryptjs');
 
 
 var LocalStrategy = require('passport-local').Strategy;

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "archiver": "^3.1.1",
     "async": "^3.1.0",
-    "bcrypt": "^4.0.1",
+    "bcryptjs": "^2.4.0",
     "compression": "^1.7.4",
     "config": "^3.2.3",
     "exe": "^1.0.2",


### PR DESCRIPTION
Because bcrypt refused to install/compile on the docker image on my raspberry pi, I have found this workaround.

I'm not a programmer and I don't know the implications but it should interest some people...
