### PR TITLE
Fix ARM autobuild

### DIFF
--- a/armhf.Dockerfile
+++ b/armhf.Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/alpine:3.12 as frontend
+FROM alpine:3.12 as frontend
 
 RUN apk add --no-cache \
   npm \

--- a/armhf.Dockerfile
+++ b/armhf.Dockerfile
@@ -1,11 +1,15 @@
 FROM arm32v7/alpine:3.12 as frontend
 
 RUN apk add --no-cache \
-  npm
+  npm \
+  curl
 
 RUN npm install -g @angular/cli
 
 WORKDIR /build
+
+RUN curl -L https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz | tar zxvf - -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static .
+
 COPY [ "package.json", "package-lock.json", "/build/" ]
 RUN npm install
 
@@ -17,7 +21,7 @@ RUN ng build --prod
 
 FROM arm32v7/alpine:3.12
 
-COPY qemu-arm-static /usr/bin
+COPY --from=frontend /build/qemu-arm-static /usr/bin
 
 ENV UID=1000 \
   GID=1000 \

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,3 +1,0 @@
-#!/bin/bash
-# downloads a local copy of qemu on docker-hub build machines
-curl -L https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz | tar zxvf - -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static .

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Register qemu-*-static for all supported processors except the 
-# current one, but also remove all registered binfmt_misc before
-docker run --rm --privileged multiarch/qemu-user-static:register --reset


### PR DESCRIPTION
The frontend build process broke ARM autobuilds -- QEMU could not be properly downloaded which caused the frontend build to fail. This PR fixes that by downloading QEMU in the Dockerfile rather than using Docker hooks.