### PR TITLE
Automated build & release via GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: continuous integration
+
+on:
+  push:
+    branches: [master, feat/*]
+    tags:
+      - v*
+  pull_request:
+      branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: setup node
+        uses: actions/setup-node@v1
+      - name: install dependencies
+        run: |
+          npm install
+          cd backend
+          npm install
+          sudo npm install -g @angular/cli
+      - name: build
+        run: ng build --prod
+      - name: prepare artifact upload
+        shell: pwsh
+        run: |
+          New-Item -Name build -ItemType Directory
+          New-Item -Path build -Name youtubedl-material -ItemType Directory
+          Copy-Item -Path ./backend/appdata -Recurse -Destination ./build/youtubedl-material
+          Copy-Item -Path ./backend/audio -Recurse -Destination ./build/youtubedl-material
+          Copy-Item -Path ./backend/authentication -Recurse -Destination ./build/youtubedl-material
+          Copy-Item -Path ./backend/public -Recurse -Destination ./build/youtubedl-material
+          Copy-Item -Path ./backend/subscriptions -Recurse -Destination ./build/youtubedl-material
+          Copy-Item -Path ./backend/video -Recurse -Destination ./build/youtubedl-material
+          Copy-Item -Path ./backend/*.js -Destination ./build/youtubedl-material
+          Copy-Item -Path ./backend/*.json -Destination ./build/youtubedl-material
+      - name: upload build artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: youtubedl-material
+          path: build
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,11 +35,58 @@ jobs:
           Copy-Item -Path ./backend/public -Recurse -Destination ./build/youtubedl-material
           Copy-Item -Path ./backend/subscriptions -Recurse -Destination ./build/youtubedl-material
           Copy-Item -Path ./backend/video -Recurse -Destination ./build/youtubedl-material
+          New-Item -Path ./build/youtubedl-material -Name users
           Copy-Item -Path ./backend/*.js -Destination ./build/youtubedl-material
           Copy-Item -Path ./backend/*.json -Destination ./build/youtubedl-material
-      - name: upload build artifacts
+      - name: upload build artifact
         uses: actions/upload-artifact@v1
         with:
           name: youtubedl-material
           path: build
-
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    if: contains(github.ref, '/tags/v')
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: YoutubeDL-Material ${{ github.ref }}
+          body: |
+            # New features
+            # Minor additions
+            # Bug fixes
+          draft: true
+          prerelease: false
+      - name: download build artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: youtubedl-material
+          path: ${{runner.temp}}/youtubedl-material
+      - name: prepare release asset
+        shell: pwsh
+        run: Compress-Archive -Path ${{runner.temp}}/youtubedl-material -DestinationPath youtubedl-material-${{ github.ref }}.zip
+      - name: upload build asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./youtubedl-material-${{ github.ref }}.zip
+          asset_name: youtubedl-material-${{ github.ref }}.zip
+          asset_content_type: application/zip
+      - name: upload docker-compose asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./docker-compose.yml
+          asset_name: docker-compose.yml
+          asset_content_type: text/plain


### PR DESCRIPTION
Hi,

as discussed in #257 this is a first draft for automatically building the app and creating (draft) releases for tagged commits.

### Building
Please forgive my ignorance here - web stuff was never my specialty :D So please have a look if the result looks as you would expect it and if e.g. the "prepare artifact upload" step makes sense like that. E.g. do the sub-folders change a lot? (-> we should not copy the sub-folders one by one but rather exclude others etc.)

It follows the basic steps as described in the `README.md` and then packages everything together so the result looks similar to previous releases here.
The build is triggered for any push to `master` or branches starting with `feat/`, tagged commits and pull requests.
The resulting archive is uploaded as a build artifact so it can be used in subsequent steps.

### Release
Again please let me know what your usual workflow here is.
I assumed a "standard" workflow: you tag a commit with a version identifier e.g. "v5.0", push it and create your release based on that version.
The "release" job in this workflow will trigger for any pushed tag following that naming convention and then:

- create a draft release with the name `YoutubeDL-Material {tag name}" and a "templated" body with "New features", "Minor additions" and "Bug fixes" headings
- download the build artifact from the previous job and repackage it as a zip file
- upload/attach that zip file to the release
- upload/attach the `docker-compose.yml` file to the release

You can (somewhat) see how it looks in my fork of your repo.

1. Pushed a tagged commit "v5.5": https://github.com/diveflo/YoutubeDL-Material/releases/tag/v5.5
2. This triggered this workflow: https://github.com/diveflo/YoutubeDL-Material/actions/runs/377411817 with a build and a release step
3. This created this draft release with the build output and the docker-compose file attached. (Sorry, I think draft releases can only be seen by the repo owner)
![image](https://user-images.githubusercontent.com/11045082/99906930-17e04b00-2cda-11eb-9247-d0186012ed48.png)

You could then "fill out" the actual release notes and publish the draft release.

Let me know what you think:)