### PR TITLE
do not push new docker images for pull requests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,6 @@ name: docker
 on:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Missed something in #257:
We don't want to build and especially push new Docker images for pull requests but only for new commits merged/pushed to master