### PR TITLE
Fix asset name in automated release creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,17 +69,20 @@ jobs:
         with:
           name: youtubedl-material
           path: ${{runner.temp}}/youtubedl-material
+      - name: extract tag name
+        id: tag_name
+        run: echo ::set-output name=tag_name::${GITHUB_REF#refs/tags/}
       - name: prepare release asset
         shell: pwsh
-        run: Compress-Archive -Path ${{runner.temp}}/youtubedl-material -DestinationPath youtubedl-material-${{ github.ref }}.zip
+        run: Compress-Archive -Path ${{runner.temp}}/youtubedl-material -DestinationPath youtubedl-material-${{ steps.tag_name.outputs.tag_name }}.zip
       - name: upload build asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./youtubedl-material-${{ github.ref }}.zip
-          asset_name: youtubedl-material-${{ github.ref }}.zip
+          asset_path: ./youtubedl-material-${{ steps.tag_name.outputs.tag_name }}.zip
+          asset_name: youtubedl-material-${{ steps.tag_name.outputs.tag_name }}.zip
           asset_content_type: application/zip
       - name: upload docker-compose asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: prepare release asset
         shell: pwsh
         run: Compress-Archive -Path ${{runner.temp}}/youtubedl-material -DestinationPath youtubedl-material-${{ steps.tag_name.outputs.tag_name }}.zip
-      - name: upload build asset
+      - name: upload release asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The GitHub actions job to automatically create a (draft) release for tagged commits introduced in #259 contained a small error regarding the release asset name.
It used the `github.ref` context variable to get the tag name to create a release asset name like `youtubedl-material-v4.3.zip`.
However, `github.ref` always includes the `refs/tags/` prefix. As forward slashes don't work in filenames, this breaks the build ([see here for example](https://github.com/Tzahi12345/YoutubeDL-Material/runs/1604409003?check_suite_focus=true)).

The fix for this is to extract the actual tag name from the `github.ref` context variable first by removing the `refs/tags/` prefix.
This is the same approach as e.g. the official GitHub create-release action [uses](https://github.com/actions/create-release/blob/main/src/create-release.js#L17).

I tested the process over in my fork of this repo and as far as I can tell the results look as expected for a tag named `v4.5`:
<img src="https://i.imgur.com/IfNek70.png">

Let me know what you think:)