### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ NOTE: If you would like to use Docker, you can skip down to the [Docker](#Docker
 Debian/Ubuntu:
 
 ```bash
-sudo apt-get install nodejs youtube-dl ffmpeg
+sudo apt-get install nodejs youtube-dl ffmpeg unzip python npm
 ```
 
 CentOS 7:


### PR DESCRIPTION
Some packages are missing for Ubuntu/Debian install, especially python. Without python package, you get the following error when trying to download from youtube:

2021-03-28T15:28:30.461Z ERROR: Error while retrieving info on video with URL https://www.youtube.com/watch?v=[some_ID] with the following message: Error: Command failed with exit code 127: /root/youtubedl-material/node_modules/youtube-dl/bin/youtube-dl --dump-json -o video/%(title)s.mp4 --write-info-json --print-json -f bestvideo+bestaudio --merge-output-format mp4 --write-thumbnail http://www.youtube.com/watch?v=[some_ID]
2021-03-28T15:28:30.461Z ERROR: /usr/bin/env: 'python': No such file or directory