### PR TITLE
Update default.json to use a longer update period

### DIFF
--- a/src/assets/default.json
+++ b/src/assets/default.json
@@ -38,7 +38,7 @@
     "Subscriptions": {
       "allow_subscriptions": true,
       "subscriptions_base_path": "subscriptions/",
-      "subscriptions_check_interval": "300",
+      "subscriptions_check_interval": "86400",
       "subscriptions_use_youtubedl_archive": true
     },
     "Users": {


### PR DESCRIPTION
See https://github.com/Tzahi12345/YoutubeDL-Material/issues/385 for context; setting this to a daily value instead of every five minutes means that updates still come in but it doesn't completely trample all other network traffic, especially if you have a lot of subscriptions.