### PR TITLE
docker-compose.yml: Use YoutubeDL-Material nightly & Dockerfile: bump alpine from 3.12 to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 as frontend
+FROM alpine:latest as frontend
 
 RUN apk add --no-cache \
   npm
@@ -15,7 +15,7 @@ RUN ng build --prod
 
 #--------------#
 
-FROM alpine:3.12
+FROM alpine:latest
 
 ENV UID=1000 \
   GID=1000 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
             - ./users:/app/users
         ports:
             - "8998:17442"
-        image: tzahi12345/youtubedl-material:latest
+        image: tzahi12345/youtubedl-material:nightly
     ytdl-mongo-db:
         image: mongo
         ports:


### PR DESCRIPTION
Needed for the MongoDB backend to make any sense, and also I think it's fair to say that nightly — at least for now — is the absolute best branch to default to.