### PR TITLE
Startup crash hotfix

### DIFF
--- a/backend/youtube-dl.js
+++ b/backend/youtube-dl.js
@@ -90,7 +90,7 @@ exports.updateYoutubeDL = async (latest_update_version) => {
 
 exports.verifyBinaryExistsLinux = () => {
     const details_json = fs.readJSONSync(CONSTS.DETAILS_BIN_PATH);
-    if (!is_windows && details_json && details_json['path'].includes('.exe')) {
+    if (!is_windows && details_json && details_json['path'] && details_json['path'].includes('.exe')) {
         details_json['path'] = 'node_modules/youtube-dl/bin/youtube-dl';
         details_json['exec'] = 'youtube-dl';
         details_json['version'] = OUTDATED_VERSION;


### PR DESCRIPTION
Introduced in #602.

Fixed bug that caused verifyBinaryExistsLinux to crash the server on startup. Not sure what conditions caused it to crash but added an additional check that will prevent it from crashing again

Solves #603.