### PR TITLE
Docker nodejs16 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN case ${TARGETPLATFORM} in \
     
 
 # Create our Ubuntu 22.04 with node 16
-FROM ubuntu:22.04 AS base
+# Go to 20.04
+FROM ubuntu:20.04 AS base
 ENV DEBIAN_FRONTEND=noninteractive
 ENV UID=1000
 ENV GID=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,9 @@
 # Fetching our ffmpeg
 FROM ubuntu:22.04 AS ffmpeg
-ARG TARGETPLATFORM
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && \
-    apt install -y --no-install-recommends wget xz-utils ca-certificates
-# Disable using ffmpeg-fetch.sh and integrate in Dockerfile, in case of err 'mismatcth platform' we enable this for counter measure.
-#COPY ffmpeg-fetch.sh .
-#RUN sh ./ffmpeg-fetch.sh
-RUN case ${TARGETPLATFORM} in \
-         "linux/amd64")  ARCH=amd64  ;; \
-         "linux/arm64")  ARCH=arm64  ;; \
-         "linux/arm/v7")  ARCH=armhf  ;; \
-    esac \ 
-    && wget -O ffmpeg.txz -c -t 10 "https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${ARCH}-static.tar.xz" && \
-    mkdir /tmp/ffmpeg && \
-    tar xf ffmpeg.txz -C /tmp/ffmpeg && \
-    cp /tmp/ffmpeg/*/ffmpeg /usr/local/bin/ffmpeg && \
-    cp /tmp/ffmpeg/*/ffprobe /usr/local/bin/ffprobe
-    
+# Use script due local build compability
+COPY ffmpeg-fetch.sh .
+RUN sh ./ffmpeg-fetch.sh
 
 # Create our Ubuntu 22.04 with node 16
 # Go to 20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV GID=1000
 ENV USER=youtube
 ENV NO_UPDATE_NOTIFIER=true
 ENV PM2_HOME=/app/pm2
-RUN groupadd -g $GID $USER && useradd --system -g $USER --uid $UID $USER && \
+RUN groupadd -g $GID $USER && useradd --system -m -g $USER --uid $UID $USER && \
     apt update && \
     apt install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM node:16-bullseye-slim as backend
 ENV NO_UPDATE_NOTIFIER=true
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app
-COPY --chown=$UID:$GID [ "backend/package.json", "backend/package-lock.json", "/app/" ]
+COPY ["backend/", "/app/" ]
 RUN npm config set strict-ssl false && \
     npm install --prod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
+# Fetching our ffmpeg
 FROM ubuntu:22.04 AS ffmpeg
 ARG TARGETPLATFORM
 ENV DEBIAN_FRONTEND=noninteractive
-#COPY ffmpeg-fetch.sh .
-#RUN sh ./ffmpeg-fetch.sh
 RUN apt update && \
     apt install -y --no-install-recommends wget xz-utils ca-certificates
+# Disable using ffmpeg-fetch.sh and integrate in Dockerfile, in case of err 'mismatcth platform' we enable this for counter measure.
+#COPY ffmpeg-fetch.sh .
+#RUN sh ./ffmpeg-fetch.sh
 RUN case ${TARGETPLATFORM} in \
          "linux/amd64")  ARCH=amd64  ;; \
          "linux/arm64")  ARCH=arm64  ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ WORKDIR /build
 COPY [ "package.json", "package-lock.json", "angular.json", "tsconfig.json", "/build/" ]
 COPY [ "src/", "/build/src/" ]
 RUN npm install && \
-    npm run build
+    npm run build && \
+    ls -al backend/public
 
 
 # Install backend deps
@@ -21,9 +22,10 @@ FROM node:16-bullseye-slim as backend
 ENV NO_UPDATE_NOTIFIER=true
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app
-COPY ["backend/", "/app/" ]
+COPY [ "backend/","/app/" ]
 RUN npm config set strict-ssl false && \
-    npm install --prod
+    npm install --prod && \
+    ls -al
 
 # Final image
 FROM node:16-bullseye-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ VOLUME ["/app/appdata"]
 
 EXPOSE 17442
 ENTRYPOINT [ "/app/entrypoint.sh" ]
-CMD [ "pm2-runtime", "pm2.config.js" ]
+CMD [ "pm2-runtime", "--raw", "pm2.config.js" ]

--- a/ffmpeg-fetch.sh
+++ b/ffmpeg-fetch.sh
@@ -22,21 +22,20 @@ esac
 
 echo "(INFO) Architecture detected: $ARCH"
 echo "(1/5) READY - Acquire temp dependencies in ffmpeg obtain layer"
-apt update && apt install -y --no-install-recommends wget xz-utils ca-certificates
+apt-get update && apt-get -y install curl xz-utils
 echo "(2/5) DOWNLOAD - Acquire latest ffmpeg and ffprobe from John van Sickle's master-sourced builds in ffmpeg obtain layer"
-#curl -o ffmpeg.txz \
-#    --connect-timeout 5 \
-#    --max-time 10 \
-#    --retry 5 \
-#    --retry-delay 0 \
-#    --retry-max-time 40 \
-#    "https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${ARCH}-static.tar.xz"
-wget -O ffmpeg.txz -c -t 10 "https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${ARCH}-static.tar.xz"
+curl -o ffmpeg.txz \
+    --connect-timeout 5 \
+    --max-time 10 \
+    --retry 5 \
+    --retry-delay 0 \
+    --retry-max-time 40 \
+    "https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${ARCH}-static.tar.xz"
 mkdir /tmp/ffmpeg
 tar xf ffmpeg.txz -C /tmp/ffmpeg
 echo "(3/5) CLEANUP - Remove temp dependencies from ffmpeg obtain layer"
-apt -y remove curl xz-utils
-apt -y autoremove --purge
+apt-get -y remove curl xz-utils
+apt-get -y autoremove
 echo "(4/5) PROVISION - Provide ffmpeg and ffprobe from ffmpeg obtain layer"
 cp /tmp/ffmpeg/*/ffmpeg /usr/local/bin/ffmpeg
 cp /tmp/ffmpeg/*/ffprobe /usr/local/bin/ffprobe

--- a/ffmpeg-fetch.sh
+++ b/ffmpeg-fetch.sh
@@ -22,20 +22,21 @@ esac
 
 echo "(INFO) Architecture detected: $ARCH"
 echo "(1/5) READY - Acquire temp dependencies in ffmpeg obtain layer"
-apt-get update && apt-get -y install curl xz-utils
+apt update && apt install -y --no-install-recommends wget xz-utils ca-certificates
 echo "(2/5) DOWNLOAD - Acquire latest ffmpeg and ffprobe from John van Sickle's master-sourced builds in ffmpeg obtain layer"
-curl -o ffmpeg.txz \
-    --connect-timeout 5 \
-    --max-time 10 \
-    --retry 5 \
-    --retry-delay 0 \
-    --retry-max-time 40 \
-    "https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${ARCH}-static.tar.xz"
+#curl -o ffmpeg.txz \
+#    --connect-timeout 5 \
+#    --max-time 10 \
+#    --retry 5 \
+#    --retry-delay 0 \
+#    --retry-max-time 40 \
+#    "https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${ARCH}-static.tar.xz"
+wget -O ffmpeg.txz -c -t 10 "https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${ARCH}-static.tar.xz"
 mkdir /tmp/ffmpeg
 tar xf ffmpeg.txz -C /tmp/ffmpeg
 echo "(3/5) CLEANUP - Remove temp dependencies from ffmpeg obtain layer"
-apt-get -y remove curl xz-utils
-apt-get -y autoremove
+apt -y remove curl xz-utils
+apt -y autoremove --purge
 echo "(4/5) PROVISION - Provide ffmpeg and ffprobe from ffmpeg obtain layer"
 cp /tmp/ffmpeg/*/ffmpeg /usr/local/bin/ffmpeg
 cp /tmp/ffmpeg/*/ffprobe /usr/local/bin/ffprobe


### PR DESCRIPTION
1. Use `ubuntu:20.04 + nodejs 16` base
2. Use of 22.04 need further identification, see https://github.com/Tzahi12345/YoutubeDL-Material/issues/608
3. Clean up some packages
4. Restructure fetching backend and building frontend
5. Rename docker-build.sh to ffmpeg-fetch.sh to prevent confusion naming
6. Add --raw to make pm2 show logs as it
7. Using `ffmpeg-fetch.sh` for compability with `docker build` method
