### PR TITLE
Add datestamped tag to nightly docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,3 +56,5 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO }}:${{secrets.DOCKERHUB_MASTER_TAG}}
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO }}:nightly-${{ steps.date.outputs.date }}
+            ghcr.io/${{ github.repository_owner }}/${{ secrets.DOCKERHUB_REPO }}:${{secrets.DOCKERHUB_MASTER_TAG}}
+            ghcr.io/${{ github.repository_owner }}/${{ secrets.DOCKERHUB_REPO }}:nightly-${{ steps.date.outputs.date }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,4 +53,6 @@ jobs:
           #     DOCKERHUB_USERNAME  : tzahi12345
           #     DOCKERHUB_REPO      : youtubedl-material
           #     DOCKERHUB_MASTER_TAG: nightly
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO }}:${{secrets.DOCKERHUB_MASTER_TAG}}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO }}:${{secrets.DOCKERHUB_MASTER_TAG}}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO }}:nightly-${{ steps.date.outputs.date }}


### PR DESCRIPTION
This will make updates to the "nightly" images visible. The `nightly` tag remains as an equivalent of `latest` for development versions, with added `nightly-YYYY-MM-DD` tags for each dev build.

This is generally good practice as using `latest` (or something equivalent) means that two deployments of the same configuration might actually be using different versions of the software. Having immutable tags means it is possible to run a particular development build at will (which might also be useful for testing bugs that only affect some versions, say).

Additionally, this is useful for my particular use case - via the [k8s-at-home](https://github.com/k8s-at-home/charts) project), I've got youtubedl-material deployed in a Kubernetes cluster alongside [Flux](https://fluxcd.io/), which monitors Docker repositories for new image versions with regex pattern matching and automatically updates running deployments to new versions (so when a new nightly build is pushed, my deployment will automatically be updated with it - except I'll be able to tell this has happened because the tag on the image has changed!).