### PR TITLE
Automatically run docker release on releases

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,19 +6,25 @@ on:
       tags:
         description: 'Docker tags'
         required: true
+  release:
+    types: [published]
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+
       - name: Set hash
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
       - name: create-json
         id: create-json
         uses: jsdaniell/create-json@1.1.2
@@ -26,15 +32,31 @@ jobs:
           name: "version.json"
           json: '{"type": "docker", "tag": "latest", "commit": "${{ steps.vars.outputs.sha_short }}", "date": "${{ steps.date.outputs.date }}"}'
           dir: 'backend/'
+
+      - name: Set image tag
+        id: tags
+        run: |
+          if [ ${{ github.event.action }} == "workflow_dispatch" ]; then
+            echo "::set-output name=tags::${{ github.event.inputs.tags }}"
+          elif [ ${{ github.event.action }} == "release" ]; then
+            echo "::set-output name=tags::${{ github.event.release.tag_name }}"
+          else
+            echo "Unknown workflow trigger: ${{ github.event.action }}! Cannot determine tags."
+            exit 1
+          fi
+
       - name: setup platform emulator
         uses: docker/setup-qemu-action@v1
+
       - name: setup multi-arch docker build
         uses: docker/setup-buildx-action@v1
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: build & push images
         uses: docker/build-push-action@v2
         with:
@@ -42,4 +64,8 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm,linux/arm64/v8
           push: true
-          tags: ${{ github.event.inputs.tags }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO }}:${{ steps.tags.outputs.tags }}
+            ghcr.io/${{ github.repository_owner }}/${{ secrets.DOCKERHUB_REPO }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ secrets.DOCKERHUB_REPO }}:${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
With this change, publishing a new release using the github web UI will automatically trigger the `docker-release.yml` workflow and build and push the image, publishing it under the `latest` tag as well as the repository tag name for the release. No more manually kicking off the release workflow!

I've also added publishing the image to ghcr.io because with Docker Hub pushing harder on subscriptions it might be nice to have a backup in place.