### PR TITLE
Use docker/metadata-action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,12 +20,15 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+
       - name: Set hash
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+
       - name: create-json
         id: create-json
         uses: jsdaniell/create-json@1.1.2
@@ -33,15 +36,35 @@ jobs:
           name: "version.json"
           json: '{"type": "docker", "tag": "${{secrets.DOCKERHUB_MASTER_TAG}}", "commit": "${{ steps.vars.outputs.sha_short }}", "date": "${{ steps.date.outputs.date }}"}'
           dir: 'backend/'
+
       - name: setup platform emulator
         uses: docker/setup-qemu-action@v1
+
       - name: setup multi-arch docker build
         uses: docker/setup-buildx-action@v1
+
+      - name: Generate Docker image metadata
+        id: docker-meta
+        uses: docker/metadata-action@v4
+        # Defaults:
+        #     DOCKERHUB_USERNAME  : tzahi12345
+        #     DOCKERHUB_REPO      : youtubedl-material
+        #     DOCKERHUB_MASTER_TAG: nightly
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO }}
+            ghcr.io/${{ github.repository_owner }}/${{ secrets.DOCKERHUB_REPO }}
+          tags: |
+            type=raw,${{secrets.DOCKERHUB_MASTER_TAG}}-{{ date 'YYYY-MM-DD' }}
+            type=raw,${{secrets.DOCKERHUB_MASTER_TAG}}
+            type=sha,prefix=sha-,format=short
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: build & push images
         uses: docker/build-push-action@v2
         with:
@@ -49,8 +72,5 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm,linux/arm64/v8
           push: true
-          # Defaults:
-          #     DOCKERHUB_USERNAME  : tzahi12345
-          #     DOCKERHUB_REPO      : youtubedl-material
-          #     DOCKERHUB_MASTER_TAG: nightly
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO }}:${{secrets.DOCKERHUB_MASTER_TAG}}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}


### PR DESCRIPTION
This will generate tags based on specific patterns, as well as add metadata labels to the images as per [the OpenContainers spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md).

I've also added a datestamped `nightly` tag to the images, as well as a `sha` tag with the specific commit in the build and included pushing the image to GitHub's container registry as well as Docker Hub. With Docker pushing hard on subscriptions these days I figure it can't hurt to have a backup in place, eh?

This will make updates to the "nightly" images visible. The `nightly` tag remains as an equivalent of `latest` for development versions, with added `nightly-YYYY-MM-DD` tags for each dev build.

This is generally good practice as using `latest` (or something equivalent) means that two deployments of the same configuration might actually be using different versions of the software. Having immutable tags means it is possible to run a particular development build at will (which might also be useful for testing bugs that only affect some versions, say).

Additionally, this is useful for my particular use case - via the [k8s-at-home](https://github.com/k8s-at-home/charts) project, I've got youtubedl-material deployed in a Kubernetes cluster alongside [Flux](https://fluxcd.io/). Flux monitors Docker repositories for new image versions with regex pattern matching and automatically updates running deployments to new versions - so when a new nightly build is pushed, my deployment will automatically be updated with it - except I'll be able to tell this has happened because the tag on the image has changed!