### PR TITLE
fix: remove write_ytdl_config 

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -147,16 +147,11 @@ if (fs.existsSync('version.json')) {
 
 // don't overwrite config if it already happened.. NOT
 // let alreadyWritten = db.get('configWriteFlag').value();
-let writeConfigMode = process.env.write_ytdl_config;
 
 // checks if config exists, if not, a config is auto generated
 config_api.configExistsCheck();
 
-if (writeConfigMode) {
-    setAndLoadConfig();
-} else {
-    loadConfig();
-}
+setAndLoadConfig();
 
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());


### PR DESCRIPTION
`write_ytdl_config` should not be used because the software should always rely on set environment variables.
In this way all the existing env variables will be loaded every time if they exists.
Should also be removed from the wiki: https://github.com/Tzahi12345/YoutubeDL-Material/wiki/Environment-Variables#ytdl_write_config