### PR TITLE
fix: remove exposed ports for mongo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
         image: tzahi12345/youtubedl-material:latest
     ytdl-mongo-db:
         image: mongo
-        ports:
-            - "27017:27017"
         logging:
             driver: "none"          
         container_name: mongo-db


### PR DESCRIPTION
exposed ports between services in the same stack is not needed