### PR TITLE
remove chown COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN npm install && \
 FROM base as backend
 WORKDIR /app
 COPY [ "backend/","/app/" ]
-RUN npm config set strict-ssl false && \
+RUN mkdir -p pm2 && \
+    npm config set strict-ssl false && \
     npm install --prod && \
     ls -al
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,10 @@ RUN npm install -g pm2 && \
 RUN pip install tcd
 WORKDIR /app
 # User 1000 already exist from base image
-COPY --chown=$UID:$GID --from=ffmpeg [ "/usr/local/bin/ffmpeg", "/usr/local/bin/ffmpeg" ]
-COPY --chown=$UID:$GID --from=ffmpeg [ "/usr/local/bin/ffprobe", "/usr/local/bin/ffprobe" ]
-COPY --chown=$UID:$GID --from=backend ["/app/","/app/"]
-COPY --chown=$UID:$GID --from=frontend [ "/build/backend/public/", "/app/public/" ]
+COPY --from=ffmpeg [ "/usr/local/bin/ffmpeg", "/usr/local/bin/ffmpeg" ]
+COPY --from=ffmpeg [ "/usr/local/bin/ffprobe", "/usr/local/bin/ffprobe" ]
+COPY --from=backend ["/app/","/app/"]
+COPY --from=frontend [ "/build/backend/public/", "/app/public/" ]
 RUN chmod +x /app/fix-scripts/*.sh
 # Add some persistence data
 #VOLUME ["/app/appdata"]


### PR DESCRIPTION
According this https://github.com/Tzahi12345/YoutubeDL-Material/issues/671 there is 243 'access denied issues'. Looking further, we copy as 1000:1000 it good if we start as USER  but as we had UID:GID modification using /entrypoint.sh to change permission `/app` dir, it not changing dir accordingly, try stay copy as root `0` so `0` can change permission  `/app` according UID:GID.