### PR TITLE
Update entrypoint.sh

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -11,6 +11,8 @@ fi
 # chown current working directory to current user
 if [ "$*" = "$CMD" ] && [ "$(id -u)" = "0" ]; then
   find . \! -user "$UID" -exec chown "$UID:$GID" -R '{}' + || echo "WARNING! Could not change directory ownership. If you manage permissions externally this is fine, otherwise you may experience issues when downloading or deleting videos."
+  usermod -u "$UID" "$USER"
+  groupmod -g "$GID" "$USER"
   exec gosu "$UID:$GID" "$0" "$@"
 fi
 


### PR DESCRIPTION
about gosu behaviour, it looking for local "existed" UID, `exec gosu UID:GID -> gosu looking for custom UID:GID -> gosu can't find it -> UID:GID became blank -> exec gosu blankUID:blankGID ->  permission denied.`
That is our issue, so updating our entrypoint to change existed user "youtube" to match custom UID and GID, will make gosu correctly use UID:GID as it existed.

Related #671 