### PR TITLE
Fixed long docker startup time by optimizing chown use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ COPY --chown=$UID:$GID --from=ffmpeg [ "/usr/local/bin/ffmpeg", "/usr/local/bin/
 COPY --chown=$UID:$GID --from=ffmpeg [ "/usr/local/bin/ffprobe", "/usr/local/bin/ffprobe" ]
 COPY --chown=$UID:$GID --from=backend ["/app/","/app/"]
 COPY --chown=$UID:$GID --from=frontend [ "/build/backend/public/", "/app/public/" ]
+RUN chown $UID:$GID .
 RUN chmod +x /app/fix-scripts/*.sh
 # Add some persistence data
 #VOLUME ["/app/appdata"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -10,7 +10,7 @@ fi
 
 # chown current working directory to current user
 if [ "$*" = "$CMD" ] && [ "$(id -u)" = "0" ]; then
-  find . \! -user "$UID" -exec chown "$UID:$GID" -R '{}' + || echo "WARNING! Could not change directory ownership. If you manage permissions externally this is fine, otherwise you may experience issues when downloading or deleting videos."
+  find . \! -user "$UID" -exec chown "$UID:$GID" '{}' + || echo "WARNING! Could not change directory ownership. If you manage permissions externally this is fine, otherwise you may experience issues when downloading or deleting videos."
   exec gosu "$UID:$GID" "$0" "$@"
 fi
 


### PR DESCRIPTION
There were two issues relating to permissions and `chown` usage which resulted in long startup times for the docker container. 

1) `/app` was owned by `root` not the default user, and  `find . \! -user "$UID"` includes the targeted directory in its results. This combined with `chown -R` resulted in the entire contents of `/app` getting resigned ownership despite not needed it when using the default user/group. See #717 
1) When using a custom user/group (ie `-e UID=1001 -e UID=1001`), the use of the `-R` flag with `chown` in the entrypoint script resulted in every file under `/app` getting reassigned ownership multiple times, as `find` results would include every file and every directory.

Fixes for these issues:

1) Set `/app` ownership to default user/group in the dockerfile. This prevents any ownership reassignments from being needed when using the default user/group.
1) Removed the `-R` flag from the `chown` usage in the entrypoint script. `find` already walks the entire directory structure.

