### PR TITLE
Force ffmpeg 5.1.1

### DIFF
--- a/docker-utils/ffmpeg-fetch.sh
+++ b/docker-utils/ffmpeg-fetch.sh
@@ -30,7 +30,7 @@ curl -o ffmpeg.txz \
     --retry 5 \
     --retry-delay 0 \
     --retry-max-time 40 \
-    "https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-${ARCH}-static.tar.xz"
+    "https://johnvansickle.com/ffmpeg/old-releases/ffmpeg-5.1.1-${ARCH}-static.tar.xz"
 mkdir /tmp/ffmpeg
 tar xf ffmpeg.txz -C /tmp/ffmpeg
 echo "(3/5) CLEANUP - Remove temp dependencies from ffmpeg obtain layer"


### PR DESCRIPTION
Closes #903

ffmpeg 6.0 is giving issues when downloading twitch streams, it works without issue with 5.1.1