### PR TITLE
Fix Missing Content-Type

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2152,6 +2152,8 @@ app.use(function(req, res, next) {
 
     let index_path = path.join(__dirname, 'public', 'index.html');
 
+    res.setHeader('Content-Type', 'text/html');
+
     fs.createReadStream(index_path).pipe(res);
 
 });


### PR DESCRIPTION
This adds text/html content type which allows the `X-Content-Type-Options nosniff` header to be used without error on reverse proxies.

Fixes #96,, fixes #125, fixes #772, fixes #983 and maybe others