### PR TITLE
Fix `.npm` cache path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ ENV USER=youtube
 ENV NO_UPDATE_NOTIFIER=true
 ENV PM2_HOME=/app/pm2
 ENV ALLOW_CONFIG_MUTATIONS=true
+ENV npm_config_cache=/app/.npm
 
 # Use NVM to get specific node version
 ENV NODE_VERSION=16.14.2


### PR DESCRIPTION
Somehow on npm startup it created directory at  `/.npm` rather than `/app/.npm`, explicitly define `.npm` folder path. This only  triggered on custom UID - GID, what a weird world

* https://github.com/Tzahi12345/YoutubeDL-Material/issues/1034