### PR TITLE
Add path to "download complete" notification body

### DIFF
--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -21,7 +21,7 @@ const NOTIFICATION_TYPE_TO_TITLE = {
 
 const NOTIFICATION_TYPE_TO_BODY = {
     task_finished: (notification) => notification['data']['task_title'],
-    download_complete: (notification) => {return `${notification['data']['file_title']}\nOriginal URL: ${notification['data']['original_url']}`},
+    download_complete: (notification) => {return `${notification['data']['file_title']}\nOriginal URL: ${notification['data']['original_url']}\nPath: ${notification['data']['file_path']}`},
     download_error: (notification) => {return `Error: ${notification['data']['download_error_message']}\nError code: ${notification['data']['download_error_type']}\n\nOriginal URL: ${notification['data']['download_url']}`}
 }
 
@@ -84,7 +84,7 @@ exports.sendTaskNotification = async (task_obj, confirmed) => {
 
 exports.sendDownloadNotification = async (file, user_uid) => {
     if (!notificationEnabled('download_complete')) return;
-    const data = {file_uid: file.uid, file_title: file.title, file_thumbnail: file.thumbnailURL, original_url: file.url};
+    const data = {file_uid: file.uid, file_title: file.title, file_path: file.path, file_thumbnail: file.thumbnailURL, original_url: file.url};
     const notification = exports.createNotification('download_complete', ['play'], data, user_uid);
     return await exports.sendNotification(notification);
 }


### PR DESCRIPTION
I didn't see a response to #978 so I tried to just follow what was there. This PR adds download path to the notification body as a newline-separated field.