### PR TITLE
Added undefined check to durationStringToNumber

### DIFF
--- a/backend/utils.js
+++ b/backend/utils.js
@@ -223,6 +223,7 @@ exports.deleteJSONFile = (file_path, type) => {
 
 exports.durationStringToNumber = (dur_str) => {
     if (typeof dur_str === 'number') return dur_str;
+    if (typeof dur_str === 'undefined') return 0;
     let num_sum = 0;
     const dur_str_parts = dur_str.split(':');
     for (let i = dur_str_parts.length-1; i >= 0; i--) {


### PR DESCRIPTION
Ran into this issue with this stack trace

TypeError: Cannot read properties of undefined (reading 'split')
    at Object.exports.durationStringToNumber (/app/utils.js:227:35)
    at /app/files.js:226:58
    at Array.reduce (<anonymous>)
    at Object.exports.calculatePlaylistDuration (/app/files.js:226:31)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.exports.createPlaylist (/app/files.js:156:22)
    at async /app/downloader.js:403:33