### PR TITLE
Fix YouTube downloads failing with 403 by updating Python and adding Deno

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ COPY docker-utils/*.sh .
 RUN chmod +x *.sh
 RUN sh ./ffmpeg-fetch.sh
 RUN sh ./fetch-twitchdownloader.sh
+RUN sh ./fetch-deno.sh
 
 
-# Create our Ubuntu 22.04 with node 16.14.2 (that specific version is required as per: https://stackoverflow.com/a/72855258/8088021)
-# Go to 20.04
-FROM ubuntu:22.04 AS base
+# Create our Ubuntu 24.04 with node 16.14.2 (that specific version is required as per: https://stackoverflow.com/a/72855258/8088021)
+# 24.04 is required because yt-dlp deprecated Python 3.10, which is what 22.04 ships
+FROM ubuntu:24.04 AS base
 ARG TARGETPLATFORM
 ARG DEBIAN_FRONTEND=noninteractive
 ENV UID=1000
@@ -23,9 +24,11 @@ ENV npm_config_cache=/app/.npm
 
 # Use NVM to get specific node version
 ENV NODE_VERSION=16.14.2
-RUN groupadd -g $GID $USER && useradd --system -m -g $USER --uid $UID $USER && \
+# Ubuntu 24.04 ships a default "ubuntu" user occupying UID/GID 1000, remove it first
+RUN { userdel -r ubuntu || true; groupdel ubuntu || true; } 2>/dev/null; \
+    groupadd -g $GID $USER && useradd --system -m -g $USER --uid $UID $USER && \
     apt update && \
-    apt install -y --no-install-recommends curl ca-certificates tzdata libicu70 libatomic1 && \
+    apt install -y --no-install-recommends curl ca-certificates tzdata libicu74 libatomic1 && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -74,17 +77,14 @@ RUN npm config set strict-ssl false && \
 FROM base
 RUN npm install -g pm2 && \
     apt update && \
-    apt install -y --no-install-recommends gosu python3-minimal python-is-python3 python3-pip atomicparsley build-essential && \
-    pip install pycryptodomex && \
-    apt remove -y --purge build-essential && \
-    apt autoremove -y --purge && \
+    apt install -y --no-install-recommends gosu python3-minimal python-is-python3 python3-pycryptodome atomicparsley && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 # User 1000 already exist from base image
-COPY --chown=$UID:$GID --from=utils [ "/usr/local/bin/ffmpeg", "/usr/local/bin/ffmpeg" ]
-COPY --chown=$UID:$GID --from=utils [ "/usr/local/bin/ffprobe", "/usr/local/bin/ffprobe" ]
-COPY --chown=$UID:$GID --from=utils [ "/usr/local/bin/TwitchDownloaderCLI", "/usr/local/bin/TwitchDownloaderCLI"]
+# Copies ffmpeg, ffprobe, TwitchDownloaderCLI and (where available) deno in one go.
+# deno is optional as it does not ship binaries for every architecture we build for.
+COPY --chown=$UID:$GID --from=utils [ "/usr/local/bin/", "/usr/local/bin/" ]
 COPY --chown=$UID:$GID --from=backend ["/app/","/app/"]
 COPY --chown=$UID:$GID --from=frontend [ "/build/backend/public/", "/app/public/" ]
 #COPY --chown=$UID:$GID --from=python ["/app/TwitchDownloaderCLI","/usr/local/bin/TwitchDownloaderCLI"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ NOTE: If you would like to use Docker, you can skip down to the [Docker](#Docker
 Required dependencies:
 
 * Node.js 16
-* Python
+* Python 3.11 or above (yt-dlp deprecated older versions)
+* A JavaScript runtime, [Deno](https://deno.com/) by default (required by yt-dlp to solve YouTube's player challenges, see the [yt-dlp wiki](https://github.com/yt-dlp/yt-dlp/wiki/EJS)). Without it YouTube downloads fail with `HTTP Error 403: Forbidden`
 
 Optional dependencies:
 

--- a/docker-utils/fetch-deno.sh
+++ b/docker-utils/fetch-deno.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# yt-dlp requires a JavaScript runtime to solve YouTube's player challenges.
+# Without one, YouTube downloads fail with "HTTP Error 403: Forbidden".
+# See: https://github.com/yt-dlp/yt-dlp/wiki/EJS
+
+case $(uname -m) in
+  x86_64)
+    ARCH=x86_64-unknown-linux-gnu;;
+  aarch64)
+    ARCH=aarch64-unknown-linux-gnu;;
+  *)
+    echo "(INFO) Deno is not available for $(uname -m), skipping JavaScript runtime installation."
+    echo "(INFO) YouTube downloads may be limited on this architecture."
+    exit 0
+esac
+
+echo "(INFO) Architecture detected: $ARCH"
+echo "(1/5) READY - Install temp dependencies in deno obtain layer"
+apt-get update && apt-get -y install curl unzip ca-certificates
+echo "(2/5) DOWNLOAD - Acquire latest deno release"
+curl -o deno.zip \
+    --connect-timeout 5 \
+    --max-time 120 \
+    --retry 5 \
+    --retry-delay 0 \
+    --retry-max-time 40 \
+    -L "https://github.com/denoland/deno/releases/latest/download/deno-${ARCH}.zip"
+echo "(3/5) PROVISION - Provide deno from deno obtain layer"
+unzip -o deno.zip -d /usr/local/bin
+chmod +x /usr/local/bin/deno
+echo "(4/5) Smoke test"
+/usr/local/bin/deno --version
+echo "(5/5) CLEANUP - Remove temporary downloads from deno obtain layer"
+rm -f deno.zip
+apt-get -y remove curl unzip
+apt-get -y autoremove


### PR DESCRIPTION
Fixes #1168

## Problem

YouTube downloads currently fail in the Docker image with:

```
Deprecated Feature: Support for Python version 3.10 has been deprecated. Please update to Python 3.11 or above
WARNING: [youtube] No supported JavaScript runtime could be found. Only deno is enabled by default; ...
ERROR: unable to download video data: HTTP Error 403: Forbidden
```

Two things changed on the yt-dlp side:

1. Python 3.10 was deprecated. The image is based on Ubuntu 22.04, which ships exactly 3.10.
2. YouTube extraction now needs a JavaScript runtime to solve the player challenges. Without one, yt-dlp falls back to the `android_vr` client, whose media URLs are rejected with `HTTP Error 403: Forbidden`.

Since the downloader binaries are plain zipapps running on the system Python, both dependencies have to come from the image.

## Changes

* Base image moved from Ubuntu 22.04 to 24.04, which ships Python 3.12
* Deno is fetched in the `utils` stage (`docker-utils/fetch-deno.sh`) and shipped in the final image, so yt-dlp picks it up automatically from `PATH`
* `pip install pycryptodomex` replaced with the `python3-pycryptodome` package, which provides the same `Cryptodome` module. This also removes the `build-essential` install/purge dance and avoids PEP 668 (`externally-managed-environment`) on 24.04
* The default `ubuntu` user of 24.04 is removed first, as it occupies UID/GID 1000
* `libicu70` bumped to `libicu74` for TwitchDownloaderCLI
* README prerequisites document the Python version and the JavaScript runtime

Deno publishes no armv7 binaries, so the fetch script skips unsupported architectures with a notice instead of failing. The binaries are copied as a directory so the build keeps working there — that architecture ends up without a JS runtime, exactly as it is today.

## Verification

Built for amd64 and tested in the resulting image:

```
python3: Python 3.12.3
node: v16.14.2
deno: deno 2.9.5 (stable, release, x86_64-unknown-linux-gnu)
Cryptodome: 3.20.0
ffmpeg version 5.1.1-static
TwitchDownloaderCLI 1.56.5
uid=1000(youtube) gid=1000(youtube) groups=1000(youtube)
```

Downloading a video with the yt-dlp binary the app itself fetched into `appdata/bin`, inside the running container:

```
[youtube] dQw4w9WgXcQ: Downloading player 727fd647-main
[youtube] [jsc:deno] Solving JS challenges using deno
[download] Destination: /tmp/e2e.mp4
[download] Download completed
[FixupM3u8] Fixing MPEG-TS in MP4 container of "/tmp/e2e.mp4"
```

The same download on the current image, with deno removed, reproduces the reported error:

```
WARNING: [youtube] No supported JavaScript runtime could be found. ...
[youtube] dQw4w9WgXcQ: Downloading android vr player API JSON
ERROR: unable to download video data: HTTP Error 403: Forbidden
```

Note that some videos remain unavailable regardless (DRM protected or region locked), but that is a separate, yt-dlp side matter.